### PR TITLE
Add support for VMs without private/public networking

### DIFF
--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -13,6 +13,9 @@ module VagrantPlugins
             @ui.info 'Skipping adding host entries (config.vm.network hostsupdater: "skip" is set)'
           end
         end
+        if not ips.any?
+          ips.push( '127.0.0.1' )
+        end
         return ips
       end
 


### PR DESCRIPTION
When VM does not have any explicit private or public networking defined in `Vagrantfile`, all services on any ports are obviously available on `127.0.0.1` by default, which is also IP used when SSH'ing to that VM.

Users might not want to setup any public/private IPs just because they want set up hostnames.

In general - is there any meaningful reason to not support this?
