### PR TITLE
Update hosts after SetHostname is called.

### DIFF
--- a/lib/vagrant-hostsupdater/plugin.rb
+++ b/lib/vagrant-hostsupdater/plugin.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
       end
 
       action_hook(:hostsupdater, :machine_action_up) do |hook|
-        hook.append(Action::UpdateHosts)
+        hook.after(Vagrant::Action::Builtin::SetHostname, Action::UpdateHosts)
       end
 
       action_hook(:hostsupdater, :machine_action_halt) do |hook|


### PR DESCRIPTION
This happens before provisioning. Which is useful for cases such as Ansible if the hostname is used in a playbook. See #31. I don't know if there is a better place that this can be hooked in but this works for me.