### PR TITLE
Allow Dynamic IP Addresses

### DIFF
--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -10,6 +10,12 @@ module VagrantPlugins
           ip = options[:ip] if key == :private_network
           ips.push(ip) if ip
         end
+		
+		network = @machine.provider.driver.read_guest_ip
+		if network["ip"]
+		  ips.push( network["ip"] ) unless ips.include? network["ip"]
+		end
+		
         return ips
       end
 


### PR DESCRIPTION
If the machine provisions a dynamic IP address (as in the case of Hyper-V
providers), allow that IP to be included in the getIPs() method. Be sure
to check that it's not already included in the IP array, though, so we
don't double-specify hard-coded IP addresses.
