### PR TITLE
Support LXC provider

### DIFF
--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -10,6 +10,12 @@ module VagrantPlugins
           ip = options[:ip] if key == :private_network
           ips.push(ip) if ip
         end
+
+        if @machine.provider_name == :lxc
+          ip = @machine.provider.capability(:public_address)
+          ips.push(ip)
+        end
+
         return ips
       end
 


### PR DESCRIPTION
LXC machine Vagrantfile uses usually default NAT interface, but connected to a virtual bridge, hence has unique IP address to communicate.
This change allows to put this IP address from public address to /etc/hosts specifically for LXC provider.