### PR TITLE
Fixes #55: Offer helpful advice to securely modify `sudoers` if needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Vagrant::Hostsupdater
 
-This plugin adds an entry to your /etc/hosts file on the host system.
+This plugin adds an entry to your `/etc/hosts` file on the host system.
 
-On **up**, **resume** and **reload** commands, it tries to add the information, if its not already existant in your hosts file. If it needs to be added, you will be asked for an administrator password, since it uses sudo to edit the file.
+On **up**, **resume** and **reload** commands, it tries to add the information, if its not already existant in your hosts file. If it needs to be added, you will be asked for an administrator password, since it uses `sudo` to edit the file. (If you are not already able to use `sudo`, some advice will be printed to help you resolve the issue.)
 
 On **halt** and **destroy**, those entries will be removed again.
 By setting the remove\_on\_suspend option, you can have them removed on **suspend**, too:


### PR DESCRIPTION
If the invoking user does not have the necessary `sudo` privileges to modify the `/etc/hosts` file in the way `vagrant-hostsupdater` needs, inform them of how to solve the problem by providing an example `sudoers` configuration snippet. The snippet is intentionally limited to apply only to the invoking user.

There are also a few small formatting fixes for the README file.