### PR TITLE
fix typo in README.md for remove_on_suspend flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Example:
 
 To keep your /etc/hosts file unchanged simply add the line below to your `VagrantFile`:
 
-    config.hostsupdater.resume_on_suspend = false
+    config.hostsupdater.remove_on_suspend = false
     
 This disables vagrant-hostsupdater from running on **suspend** and **halt**.
         


### PR DESCRIPTION
README has "resume_on_suspend" but flag is defined as "remove_on_suspend"