### PR TITLE
Make Passwordless sudo instructions use user-defined path to 'sed'

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ stop asking password when updating hosts file:
 
     # Allow passwordless startup of Vagrant with vagrant-hostsupdater.
     Cmnd_Alias VAGRANT_HOSTS_ADD = /bin/sh -c echo "*" >> /etc/hosts
-    Cmnd_Alias VAGRANT_HOSTS_REMOVE = /usr/bin/sed -i -e /*/ d /etc/hosts
+    Cmnd_Alias VAGRANT_HOSTS_REMOVE = /usr/bin/env sed -i -e /*/ d /etc/hosts
     %admin ALL=(root) NOPASSWD: VAGRANT_HOSTS_ADD, VAGRANT_HOSTS_REMOVE
     
         


### PR DESCRIPTION
Alter the 'Passwordless sudo' section in README.md to use the user's locally-set path to 'sed' instead of hard-coding the path.  This resolves Issue #103.