### PR TITLE
get hosts file path from VAGRANT_HOSTSUPDATER_PATH

### DIFF
--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -1,7 +1,11 @@
 module VagrantPlugins
   module HostsUpdater
     module HostsUpdater
-      @@hosts_path = Vagrant::Util::Platform.windows? ? File.expand_path('system32/drivers/etc/hosts', ENV['windir']) : '/etc/hosts'
+      if ENV['VAGRANT_HOSTSUPDATER_PATH']
+        @@hosts_path = ENV['VAGRANT_HOSTSUPDATER_PATH']
+      else
+        @@hosts_path = Vagrant::Util::Platform.windows? ? File.expand_path('system32/drivers/etc/hosts', ENV['windir']) : '/etc/hosts'
+      end
 
       def getIps
         ips = []


### PR DESCRIPTION
This allows to set an environment variable VAGRANT_HOSTSUPDATER_PATH to be used to point to the file used as hosts file. 
This is nice when you do not want to change the /etc/hosts file or have some custom dns setup.
E.g. [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html) allows you to use any file or all files from a directory with the `--addn-hosts` option.
