### PR TITLE
Fixed passwordless sudo instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,12 @@ This disables vagrant-hostsupdater from running on **suspend** and **halt**.
 
 ## Passwordless sudo
 
-Add the following snippet to the top of the sudoers file using `sudo visudo`. It will make vagrant
-stop asking password when updating hosts file:
+To allow vagrant to automatically update the hosts file without asking for a sudo password, add the following snippet to a new sudoers file include, i.e. `sudo visudo -f /etc/sudoers.d/vagrant_hostsupdater`:
 
     # Allow passwordless startup of Vagrant with vagrant-hostsupdater.
     Cmnd_Alias VAGRANT_HOSTS_ADD = /bin/sh -c echo "*" >> /etc/hosts
     Cmnd_Alias VAGRANT_HOSTS_REMOVE = /usr/bin/env sed -i -e /*/ d /etc/hosts
-    %admin ALL=(root) NOPASSWD: VAGRANT_HOSTS_ADD, VAGRANT_HOSTS_REMOVE
+    %sudo ALL=(root) NOPASSWD: VAGRANT_HOSTS_ADD, VAGRANT_HOSTS_REMOVE
 
 Note: If vagrant still asks for a password on commands that trigger the `VAGRANT_HOSTS_REMOVE` alias above (like
 **halt** or **suspend**), this might indicate that the location of **sed** in the `VAGRANT_HOSTS_REMOVE` alias is

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ To allow vagrant to automatically update the hosts file without asking for a sud
     Cmnd_Alias VAGRANT_HOSTS_REMOVE = /usr/bin/env sed -i -e /*/ d /etc/hosts
     %sudo ALL=(root) NOPASSWD: VAGRANT_HOSTS_ADD, VAGRANT_HOSTS_REMOVE
 
-Note: If vagrant still asks for a password on commands that trigger the `VAGRANT_HOSTS_REMOVE` alias above (like
+Notes:
+
+- For MacOS, change %sudo to %admin on the last line above
+- If vagrant still asks for a password on commands that trigger the `VAGRANT_HOSTS_REMOVE` alias above (like
 **halt** or **suspend**), this might indicate that the location of **sed** in the `VAGRANT_HOSTS_REMOVE` alias is
 pointing to the wrong location. The solution is to find the location of **sed** (ex. `which sed`) and
 replace that location in the `VAGRANT_HOSTS_REMOVE` alias. For example, on some newer Ubuntu versions (seen as


### PR DESCRIPTION
The passwordless sudo instructions do not work, at least on Ubuntu 16.04. Even after following the instructions, you have to enter a sudo password every time the hosts file is updated.

I think this is actually a regression. The setup instructions were altered in PR #82, specifically this commit: https://github.com/cogitatio/vagrant-hostsupdater/commit/07409ae4c0ff9358e0f92c75d30a689b4fb3b6be

There's no documentation about why this change was made, but I think it needs to be reverted. Besides the fact that the old instructions worked and the new ones don't:

1. Updating the sudoers file is bad practice, you should use sudoers.d
2. Inserting content into the top of the sudoers file seems like bad practice
3. I'm not sure how this would ever work since it refers to %admin instead of %sudo