### PR TITLE
Add Docker support

### DIFF
--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -23,6 +23,9 @@ module VagrantPlugins
         if @machine.provider_name == :lxc
           ip = @machine.provider.capability(:public_address)
           ips.push(ip)
+        elsif @machine.provider_name == :docker
+          ip = @machine.provider.capability(:public_address)
+          ips.push(ip)
         end
 
         return ips


### PR DESCRIPTION
If provider is Docker, we add public_address from provider to list of valid IPs. This is the exactly same thing hostsupdater does for LXC hosts.

Related to issue #52 .