### PR TITLE
Add 127.0.0.1 to ips if port forwarding is configured

### DIFF
--- a/lib/vagrant-hostsupdater/HostsUpdater.rb
+++ b/lib/vagrant-hostsupdater/HostsUpdater.rb
@@ -17,12 +17,18 @@ module VagrantPlugins
         if ip = getAwsPublicIp
           ips.push(ip)
         else
-            @machine.config.vm.networks.each do |network|
-              key, options = network[0], network[1]
-              ip = options[:ip] if (key == :private_network || key == :public_network) && options[:hostsupdater] != "skip"
-              ips.push(ip) if ip
-              if options[:hostsupdater] == 'skip'
-                @ui.info '[vagrant-hostsupdater] Skipping adding host entries (config.vm.network hostsupdater: "skip" is set)'
+          @machine.config.vm.networks.each do |network|
+            key, options = network[0], network[1]
+            if options[:hostsupdater] == "skip"
+              @ui.info '[vagrant-hostsupdater] Skipping adding host entries (config.vm.network hostsupdater: "skip" is set)'
+              next
+            end
+            if key == :private_network || key == :public_network
+              ips.push(options[:ip])
+              next
+            end
+            if key == :forwarded_port
+              ips.push('127.0.0.1')
             end
           end
         end


### PR DESCRIPTION
Some hosts might point to forwarded ports on host rather than actual ports in the guest machine. However, if 127.0.0.1 is not in the list of IPs, such hosts are not added to the hosts file.